### PR TITLE
Did TODO check through shellfuncs for short options converting to long options

### DIFF
--- a/install
+++ b/install
@@ -3,7 +3,6 @@
 # user to pull scripts as shell functions in their
 # shell session.
 # Usage: curl --silent https://raw.githubusercontent.com/reap2sow1/shellfuncs/main/install | bash
-# TODO check through shellfuncs for command flags that be expanded into a long option
 set -e
 PWD="$(pwd)"
 PROGRAM_NAME="$(basename "$0")"

--- a/others/shellfuncs_setup_editor
+++ b/others/shellfuncs_setup_editor
@@ -1,4 +1,5 @@
 #!/bin/bash
+#
 # Small setup script for editor of choice from dotfiles repo.
 # Usage: Can be installed standalone, but setup_editor is called from 'install' script in same repo.
 
@@ -39,6 +40,7 @@ shellfuncs_setup_editor () {
 _shellfuncs_setup_vscodium () {
     GPG_URL="https://gitlab.com/paulcarroty/vscodium-deb-rpm-repo/raw/master/pub.gpg"
     CODIUM_USER_SETTINGS_PATH="${HOME}/.config/VSCodium/User/settings.json"
+    CODIUM_USER_SETTINGS_DIR="$(dirname "$CODIUM_USER_SETTINGS_PATH")"
     PACKAGE_NAME="codium"
     SYSTEM_DEPENDENCIES=(
         wget
@@ -52,7 +54,7 @@ _shellfuncs_setup_vscodium () {
             echo -e "$ERROR could not install all required system packages"
             return 1
         fi
-        wget -qO - "$GPG_URL" | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/vscodium.gpg
+        wget --quiet --output-document - "$GPG_URL" | gpg --dearmor | sudo dd of=/etc/apt/trusted.gpg.d/vscodium.gpg
         echo 'deb https://paulcarroty.gitlab.io/vscodium-deb-rpm-repo/debs/ vscodium main' | sudo tee --append /etc/apt/sources.list.d/vscodium.list 
         if sudo apt-get update && ! sudo apt-get install "$PACKAGE_NAME" --assume-yes; then
             echo -e "$ERROR could not install editor package '$PACKAGE_NAME'"
@@ -73,13 +75,15 @@ _shellfuncs_setup_vscodium () {
         # hence we want to grep on the '/'
         # NOTE: if the system already has a secret gpg key on it, this will fail to attach the correct key 
         #       to git (one-liner assigns all the secret keys to the git configuration).
+        # NOTE2: Omitting the expansion of some short flags used below, to perserve readability
         GPG_KEY_ID="$(gpg --list-secret-keys --keyid-format LONG | grep sec | grep -ohE "\/[[:alnum:]]+" | grep -ohE "[[:alnum:]]+")"
         git config --global user.signingkey "$GPG_KEY_ID"
         COMMIT_SIGNING_KEY_VALUE='{"git.enableCommitSigning": true}'
+        if ! [ -d "$CODIUM_USER_SETTINGS_DIR)" ]; then mkdir --parents "$CODIUM_USER_SETTINGS_DIR"; fi
         # does the codium setting's file already exist and is it not empty
         if [ -f "$CODIUM_USER_SETTINGS_PATH" ] && [ -s "$CODIUM_USER_SETTINGS_PATH" ]; then
             # is commit signing NOT enabled on codium (aka is the key/value for this NOT in the settings file)
-            if [ "$(grep "git.enableCommitSigning" "$CODIUM_USER_SETTINGS_PATH" | grep -c true)" -eq 0 ]; then
+            if [ "$(grep "git.enableCommitSigning" "$CODIUM_USER_SETTINGS_PATH" | grep --count true)" -eq 0 ]; then
                 TEMP_JSON_FILE_NAME="$(dirname "${CODIUM_USER_SETTINGS_PATH}")/temp.json"
                 jq < "$CODIUM_USER_SETTINGS_PATH" ". + $COMMIT_SIGNING_KEY_VALUE" > "$TEMP_JSON_FILE_NAME"
                 mv "$TEMP_JSON_FILE_NAME" "$CODIUM_USER_SETTINGS_PATH"
@@ -88,4 +92,5 @@ _shellfuncs_setup_vscodium () {
             echo "$COMMIT_SIGNING_KEY_VALUE" | jq . > "$CODIUM_USER_SETTINGS_PATH"
         fi
     fi
+    return 0
 }

--- a/scripts/shellfuncs_enable_promiscuous_mode_esxi
+++ b/scripts/shellfuncs_enable_promiscuous_mode_esxi
@@ -13,4 +13,5 @@
 shellfuncs_enable_promiscuous_mode_esxi() {
     sudo chgrp adm "/dev/vmnet${1}"
     sudo chmod 660 "/dev/vmnet${1}"
+    return 
 }

--- a/scripts/shellfuncs_g++_basic_options
+++ b/scripts/shellfuncs_g++_basic_options
@@ -8,6 +8,6 @@
 #   Basic compilation options 
 #######################################
 shellfuncs_g++_basic_options () {
-    g++ --help | grep -e "-o\s\|-[c]\s\|-[S]\|-[E]"
+    g++ --help | grep --regexp="-o\s\|-[c]\s\|-[S]\|-[E]"
     return
 }

--- a/scripts/shellfuncs_install_codium_extension
+++ b/scripts/shellfuncs_install_codium_extension
@@ -31,13 +31,13 @@ shellfuncs_install_codium_extension () {
     OUTPUT_FILE_NAME_GZ="$EXTENSION_PUBLISHER.$EXTENSION_NAME-$EXTENSION_VERSION.gz"
     OUTPUT_FILE_NAME="$EXTENSION_PUBLISHER.$EXTENSION_NAME-$EXTENSION_VERSION.vsix"
     EXT_URL="https://marketplace.visualstudio.com/_apis/public/gallery/publishers/$EXTENSION_PUBLISHER/vsextensions/$EXTENSION_NAME/$EXTENSION_VERSION/vspackage"
-    if ! wget -qO "$OUTPUT_FILE_NAME_GZ" "$EXT_URL"; then
+    if ! wget --quiet --output-document="$OUTPUT_FILE_NAME_GZ" "$EXT_URL"; then
         echo -e "$ERROR failed to <download> $EXTENSION!"
         return 1
     fi
     # wget downloads files compressed as gzip
     # https://stackoverflow.com/questions/60090123/extensions-for-vs-code-not-working-when-downloaded-with-wget-or-curl
-    gunzip -cf "$OUTPUT_FILE_NAME_GZ" > "$OUTPUT_FILE_NAME"
+    gunzip --stdout --force "$OUTPUT_FILE_NAME_GZ" > "$OUTPUT_FILE_NAME"
     # NOTE: installing a new extension will overwrite any previous version installed
     # NOTE2: weirdly installing an extension successfully may still signal an issue...
     # might have todo with exceptions thrown from installation (even though the installation works)
@@ -45,5 +45,5 @@ shellfuncs_install_codium_extension () {
     rm "$OUTPUT_FILE_NAME_GZ"
     rm "$OUTPUT_FILE_NAME"
     echo -e "$SUCCESS installed $EXTENSION $EXTENSION_VERSION successfully"
-    return
+    return 0
 }

--- a/scripts/shellfuncs_install_tortoisehg
+++ b/scripts/shellfuncs_install_tortoisehg
@@ -69,7 +69,7 @@ shellfuncs_install_tortoisehg () {
     echo "${PROGRAM_NAME}: Installed python dependencies"
     
     # lets build tortoisehg now, and install a desktop entry!
-    if ! hg clone "$TORTOISEHG_REPO_URL" -r "$BRANCH" "$PWD"; then
+    if ! hg clone "$TORTOISEHG_REPO_URL" --rev "$BRANCH" "$PWD"; then
         echo -e "$ERROR could not download tortoisehg source"
         _shellfuncs_install_tortoisehg_cleanup && return 1
     fi
@@ -80,7 +80,7 @@ shellfuncs_install_tortoisehg () {
     # in a python 3 symlink into a temp directory and shove that onto the PATH first
     ! mkdir $TEMP_DIR_NAME && _shellfuncs_install_tortoisehg_cleanup && return 1
     ! cd "$TEMP_DIR_NAME" && _shellfuncs_install_tortoisehg_cleanup && return 1
-    if ! sudo ln -sf "$(which python3)" "./python"; then
+    if ! sudo ln --symbolic --force "$(which python3)" "./python"; then
         echo -e "$ERROR could not establish symlink for python to python3"
         _shellfuncs_install_tortoisehg_cleanup && return 1
     fi
@@ -108,7 +108,7 @@ _EOF_
         _shellfuncs_install_tortoisehg_cleanup && return 1
     fi
     echo -e "$SUCCESS installed tortoisehg, restart the shell session to restore original PATH"
-    cd .. || return
+    cd .. || return 0
 }
 
 _shellfuncs_install_tortoisehg_cleanup (){

--- a/scripts/shellfuncs_new_devmachine_setup
+++ b/scripts/shellfuncs_new_devmachine_setup
@@ -31,7 +31,7 @@ _EOF_
         shellfuncs_setup_editor
         ;;
     *)  echo "exited"
-        return
+        return 0
         ;;
 
     esac

--- a/scripts/shellfuncs_show_codium_exts_updates
+++ b/scripts/shellfuncs_show_codium_exts_updates
@@ -17,6 +17,7 @@ shellfuncs_show_codium_exts_updates () {
         # codium returns an extension as extension@local_version (e.g. gerane.Theme-Boron@0.0.7)
         # the definition of 'codium extension' may differ in other scripts, the definition of this is above for this script
         IFS='@' read -r extension_name local_version <<< "$extension"
+        # NOTE2: Omitting the expansion of some short flags used below, to perserve readability
         marketplace_version="$(wget -qO - https://marketplace.visualstudio.com/items?itemName="$extension_name" | grep -ohE "\"VersionValue\":\"[0-9\.]+\"" | grep -oh "[0-9].*[0-9]")"
         if [ -n "$marketplace_version" ]; then
             # assuming extension version on marketpkace is ALWAYS newer
@@ -25,5 +26,5 @@ shellfuncs_show_codium_exts_updates () {
             fi
         fi
     done
-    return
+    return 0
 }

--- a/scripts/shellfuncs_upgrade_all_without_grub
+++ b/scripts/shellfuncs_upgrade_all_without_grub
@@ -6,13 +6,13 @@
 # Used to upgrade all deb packages except those
 # pertaining to grub.
 # Outputs:
-#   Normal apt installation output
+#   Normal apt-get installation output
 #######################################
 shellfuncs_upgrade_all_without_grub () {
-    sudo apt list --upgradable \
-    | grep -v grub \
-    | cut -f1 -d"/" \
-    | tail -n +2 \
-    | xargs -d '\n' -- sudo apt install -y 
+    sudo apt-get list --upgradable \
+    | grep --invert-match grub \
+    | cut --fields=1 --delimiter="/" \
+    | tail --lines=+2 \
+    | xargs --delimiter='\n' -- sudo apt-get install --assume-yes
     return
 }


### PR DESCRIPTION
- Also appended returns with 'exiting' status codes of 0.
    - This is where appropriate, some were fine
        referencing the status code of the last command ran.
- Fix bug where if directory for VSCodium did not exist, then the settings file would fail to be created in any case.